### PR TITLE
feat:Add Color Palette Classes, Enums, and JSON Converters in Ideogram Namespace

### DIFF
--- a/src/libs/Ideogram/Generated/Ideogram.Models.ColorPaletteMember.g.cs
+++ b/src/libs/Ideogram/Generated/Ideogram.Models.ColorPaletteMember.g.cs
@@ -1,0 +1,33 @@
+
+#nullable enable
+
+namespace Ideogram
+{
+    /// <summary>
+    /// A member of a color palette.
+    /// </summary>
+    public sealed partial class ColorPaletteMember
+    {
+        /// <summary>
+        /// The hexadecimal representation of the color with an optional chosen weight<br/>
+        /// Example: #FFFFFF
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("color_hex")]
+        [global::System.Text.Json.Serialization.JsonRequired]
+        public required string ColorHex { get; set; }
+
+        /// <summary>
+        /// The weight of the color in the color palette.<br/>
+        /// Example: 0.25
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("color_weight")]
+        [global::System.Text.Json.Serialization.JsonRequired]
+        public required double ColorWeight { get; set; }
+
+        /// <summary>
+        /// Additional properties that are not explicitly defined in the schema
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonExtensionData]
+        public global::System.Collections.Generic.IDictionary<string, object> AdditionalProperties { get; set; } = new global::System.Collections.Generic.Dictionary<string, object>();
+    }
+}

--- a/src/libs/Ideogram/Generated/Ideogram.Models.ColorPalettePresetName.g.cs
+++ b/src/libs/Ideogram/Generated/Ideogram.Models.ColorPalettePresetName.g.cs
@@ -1,0 +1,88 @@
+
+#nullable enable
+
+namespace Ideogram
+{
+    /// <summary>
+    /// A color palette preset value<br/>
+    /// Example: PASTEL
+    /// </summary>
+    public enum ColorPalettePresetName
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        EMBER,
+        /// <summary>
+        /// 
+        /// </summary>
+        FRESH,
+        /// <summary>
+        /// 
+        /// </summary>
+        JUNGLE,
+        /// <summary>
+        /// 
+        /// </summary>
+        MAGIC,
+        /// <summary>
+        /// 
+        /// </summary>
+        MELON,
+        /// <summary>
+        /// 
+        /// </summary>
+        MOSAIC,
+        /// <summary>
+        /// 
+        /// </summary>
+        PASTEL,
+        /// <summary>
+        /// 
+        /// </summary>
+        ULTRAMARINE,
+    }
+
+    /// <summary>
+    /// Enum extensions to do fast conversions without the reflection.
+    /// </summary>
+    public static class ColorPalettePresetNameExtensions
+    {
+        /// <summary>
+        /// Converts an enum to a string.
+        /// </summary>
+        public static string ToValueString(this ColorPalettePresetName value)
+        {
+            return value switch
+            {
+                ColorPalettePresetName.EMBER => "EMBER",
+                ColorPalettePresetName.FRESH => "FRESH",
+                ColorPalettePresetName.JUNGLE => "JUNGLE",
+                ColorPalettePresetName.MAGIC => "MAGIC",
+                ColorPalettePresetName.MELON => "MELON",
+                ColorPalettePresetName.MOSAIC => "MOSAIC",
+                ColorPalettePresetName.PASTEL => "PASTEL",
+                ColorPalettePresetName.ULTRAMARINE => "ULTRAMARINE",
+                _ => throw new global::System.ArgumentOutOfRangeException(nameof(value), value, null),
+            };
+        }
+        /// <summary>
+        /// Converts an string to a enum.
+        /// </summary>
+        public static ColorPalettePresetName? ToEnum(string value)
+        {
+            return value switch
+            {
+                "EMBER" => ColorPalettePresetName.EMBER,
+                "FRESH" => ColorPalettePresetName.FRESH,
+                "JUNGLE" => ColorPalettePresetName.JUNGLE,
+                "MAGIC" => ColorPalettePresetName.MAGIC,
+                "MELON" => ColorPalettePresetName.MELON,
+                "MOSAIC" => ColorPalettePresetName.MOSAIC,
+                "PASTEL" => ColorPalettePresetName.PASTEL,
+                "ULTRAMARINE" => ColorPalettePresetName.ULTRAMARINE,
+                _ => null,
+            };
+        }
+    }
+}

--- a/src/libs/Ideogram/Generated/Ideogram.Models.ColorPaletteWithMembers.g.cs
+++ b/src/libs/Ideogram/Generated/Ideogram.Models.ColorPaletteWithMembers.g.cs
@@ -1,0 +1,24 @@
+
+#nullable enable
+
+namespace Ideogram
+{
+    /// <summary>
+    /// A color palette represented only via its members
+    /// </summary>
+    public sealed partial class ColorPaletteWithMembers
+    {
+        /// <summary>
+        /// A list of ColorPaletteMembers that define the color palette.
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("members")]
+        [global::System.Text.Json.Serialization.JsonRequired]
+        public required global::System.Collections.Generic.IList<global::Ideogram.ColorPaletteMember> Members { get; set; }
+
+        /// <summary>
+        /// Additional properties that are not explicitly defined in the schema
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonExtensionData]
+        public global::System.Collections.Generic.IDictionary<string, object> AdditionalProperties { get; set; } = new global::System.Collections.Generic.Dictionary<string, object>();
+    }
+}

--- a/src/libs/Ideogram/Generated/Ideogram.Models.ColorPaletteWithPresetName.g.cs
+++ b/src/libs/Ideogram/Generated/Ideogram.Models.ColorPaletteWithPresetName.g.cs
@@ -1,0 +1,26 @@
+
+#nullable enable
+
+namespace Ideogram
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public sealed partial class ColorPaletteWithPresetName
+    {
+        /// <summary>
+        /// A color palette preset value<br/>
+        /// Example: PASTEL
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("name")]
+        [global::System.Text.Json.Serialization.JsonConverter(typeof(global::Ideogram.JsonConverters.ColorPalettePresetNameJsonConverter))]
+        [global::System.Text.Json.Serialization.JsonRequired]
+        public required global::Ideogram.ColorPalettePresetName Name { get; set; }
+
+        /// <summary>
+        /// Additional properties that are not explicitly defined in the schema
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonExtensionData]
+        public global::System.Collections.Generic.IDictionary<string, object> AdditionalProperties { get; set; } = new global::System.Collections.Generic.Dictionary<string, object>();
+    }
+}

--- a/src/libs/Ideogram/Generated/Ideogram.Models.ColorPaletteWithPresetNameOrMembers.g.cs
+++ b/src/libs/Ideogram/Generated/Ideogram.Models.ColorPaletteWithPresetNameOrMembers.g.cs
@@ -1,0 +1,166 @@
+using System.Linq;
+#pragma warning disable CS0618 // Type or member is obsolete
+
+#nullable enable
+
+namespace Ideogram
+{
+    /// <summary>
+    /// A color palette for generation, must EITHER be specified via one of the presets (name) or explicitly via hexadecimal representations of the color with optional weights (members).
+    /// </summary>
+    public readonly partial struct ColorPaletteWithPresetNameOrMembers : global::System.IEquatable<ColorPaletteWithPresetNameOrMembers>
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+#if NET6_0_OR_GREATER
+        public global::Ideogram.ColorPaletteWithPresetName?  { get; init; }
+#else
+        public global::Ideogram.ColorPaletteWithPresetName?  { get; }
+#endif
+
+        /// <summary>
+        /// 
+        /// </summary>
+#if NET6_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, nameof())]
+#endif
+        public bool Is =>  != null;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public static implicit operator ColorPaletteWithPresetNameOrMembers(global::Ideogram.ColorPaletteWithPresetName value) => new ColorPaletteWithPresetNameOrMembers(value);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public static implicit operator global::Ideogram.ColorPaletteWithPresetName?(ColorPaletteWithPresetNameOrMembers @this) => @this.;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public ColorPaletteWithPresetNameOrMembers(global::Ideogram.ColorPaletteWithPresetName? value)
+        {
+             = value;
+        }
+
+        /// <summary>
+        /// A color palette represented only via its members
+        /// </summary>
+#if NET6_0_OR_GREATER
+        public global::Ideogram.ColorPaletteWithMembers?  { get; init; }
+#else
+        public global::Ideogram.ColorPaletteWithMembers?  { get; }
+#endif
+
+        /// <summary>
+        /// 
+        /// </summary>
+#if NET6_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, nameof())]
+#endif
+        public bool Is =>  != null;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public static implicit operator ColorPaletteWithPresetNameOrMembers(global::Ideogram.ColorPaletteWithMembers value) => new ColorPaletteWithPresetNameOrMembers(value);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public static implicit operator global::Ideogram.ColorPaletteWithMembers?(ColorPaletteWithPresetNameOrMembers @this) => @this.;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public ColorPaletteWithPresetNameOrMembers(global::Ideogram.ColorPaletteWithMembers? value)
+        {
+             = value;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public ColorPaletteWithPresetNameOrMembers(
+            global::Ideogram.ColorPaletteWithPresetName? ,
+            global::Ideogram.ColorPaletteWithMembers? 
+            )
+        {
+             = ;
+             = ;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public object? Object =>
+             as object ??
+             as object 
+            ;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public bool Validate()
+        {
+            return Is && !Is || !Is && Is;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public override int GetHashCode()
+        {
+            var fields = new object?[]
+            {
+                ,
+                typeof(global::Ideogram.ColorPaletteWithPresetName),
+                ,
+                typeof(global::Ideogram.ColorPaletteWithMembers),
+            };
+            const int offset = unchecked((int)2166136261);
+            const int prime = 16777619;
+            static int HashCodeAggregator(int hashCode, object? value) => value == null
+                ? (hashCode ^ 0) * prime
+                : (hashCode ^ value.GetHashCode()) * prime;
+            return fields.Aggregate(offset, HashCodeAggregator);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public bool Equals(ColorPaletteWithPresetNameOrMembers other)
+        {
+            return
+                global::System.Collections.Generic.EqualityComparer<global::Ideogram.ColorPaletteWithPresetName?>.Default.Equals(, other.) &&
+                global::System.Collections.Generic.EqualityComparer<global::Ideogram.ColorPaletteWithMembers?>.Default.Equals(, other.) 
+                ;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public static bool operator ==(ColorPaletteWithPresetNameOrMembers obj1, ColorPaletteWithPresetNameOrMembers obj2)
+        {
+            return global::System.Collections.Generic.EqualityComparer<ColorPaletteWithPresetNameOrMembers>.Default.Equals(obj1, obj2);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public static bool operator !=(ColorPaletteWithPresetNameOrMembers obj1, ColorPaletteWithPresetNameOrMembers obj2)
+        {
+            return !(obj1 == obj2);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public override bool Equals(object? obj)
+        {
+            return obj is ColorPaletteWithPresetNameOrMembers o && Equals(o);
+        }
+    }
+}

--- a/src/libs/Ideogram/Generated/Ideogram.Models.ImageRequest.g.cs
+++ b/src/libs/Ideogram/Generated/Ideogram.Models.ImageRequest.g.cs
@@ -72,6 +72,13 @@ namespace Ideogram
         public global::Ideogram.Resolution? Resolution { get; set; }
 
         /// <summary>
+        /// A color palette for generation, must EITHER be specified via one of the presets (name) or explicitly via hexadecimal representations of the color with optional weights (members).
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("color_palette")]
+        [global::System.Text.Json.Serialization.JsonConverter(typeof(global::Ideogram.JsonConverters.ColorPaletteWithPresetNameOrMembersJsonConverter))]
+        public global::Ideogram.ColorPaletteWithPresetNameOrMembers? ColorPalette { get; set; }
+
+        /// <summary>
         /// Additional properties that are not explicitly defined in the schema
         /// </summary>
         [global::System.Text.Json.Serialization.JsonExtensionData]

--- a/src/libs/Ideogram/Generated/JsonConverters.ColorPalettePresetName.g.cs
+++ b/src/libs/Ideogram/Generated/JsonConverters.ColorPalettePresetName.g.cs
@@ -1,0 +1,49 @@
+#nullable enable
+
+namespace Ideogram.JsonConverters
+{
+    /// <inheritdoc />
+    public sealed class ColorPalettePresetNameJsonConverter : global::System.Text.Json.Serialization.JsonConverter<global::Ideogram.ColorPalettePresetName>
+    {
+        /// <inheritdoc />
+        public override global::Ideogram.ColorPalettePresetName Read(
+            ref global::System.Text.Json.Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            switch (reader.TokenType)
+            {
+                case global::System.Text.Json.JsonTokenType.String:
+                {
+                    var stringValue = reader.GetString();
+                    if (stringValue != null)
+                    {
+                        return global::Ideogram.ColorPalettePresetNameExtensions.ToEnum(stringValue) ?? default;
+                    }
+                    
+                    break;
+                }
+                case global::System.Text.Json.JsonTokenType.Number:
+                {
+                    var numValue = reader.GetInt32();
+                    return (global::Ideogram.ColorPalettePresetName)numValue;
+                }
+                default:
+                    throw new global::System.ArgumentOutOfRangeException(nameof(reader));
+            }
+
+            return default;
+        }
+
+        /// <inheritdoc />
+        public override void Write(
+            global::System.Text.Json.Utf8JsonWriter writer,
+            global::Ideogram.ColorPalettePresetName value,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            writer = writer ?? throw new global::System.ArgumentNullException(nameof(writer));
+
+            writer.WriteStringValue(global::Ideogram.ColorPalettePresetNameExtensions.ToValueString(value));
+        }
+    }
+}

--- a/src/libs/Ideogram/Generated/JsonConverters.ColorPalettePresetNameNullable.g.cs
+++ b/src/libs/Ideogram/Generated/JsonConverters.ColorPalettePresetNameNullable.g.cs
@@ -1,0 +1,56 @@
+#nullable enable
+
+namespace Ideogram.JsonConverters
+{
+    /// <inheritdoc />
+    public sealed class ColorPalettePresetNameNullableJsonConverter : global::System.Text.Json.Serialization.JsonConverter<global::Ideogram.ColorPalettePresetName?>
+    {
+        /// <inheritdoc />
+        public override global::Ideogram.ColorPalettePresetName? Read(
+            ref global::System.Text.Json.Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            switch (reader.TokenType)
+            {
+                case global::System.Text.Json.JsonTokenType.String:
+                {
+                    var stringValue = reader.GetString();
+                    if (stringValue != null)
+                    {
+                        return global::Ideogram.ColorPalettePresetNameExtensions.ToEnum(stringValue);
+                    }
+                    
+                    break;
+                }
+                case global::System.Text.Json.JsonTokenType.Number:
+                {
+                    var numValue = reader.GetInt32();
+                    return (global::Ideogram.ColorPalettePresetName)numValue;
+                }
+                default:
+                    throw new global::System.ArgumentOutOfRangeException(nameof(reader));
+            }
+
+            return default;
+        }
+
+        /// <inheritdoc />
+        public override void Write(
+            global::System.Text.Json.Utf8JsonWriter writer,
+            global::Ideogram.ColorPalettePresetName? value,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            writer = writer ?? throw new global::System.ArgumentNullException(nameof(writer));
+
+            if (value == null)
+            {
+                writer.WriteNullValue();
+            }
+            else
+            {
+                writer.WriteStringValue(global::Ideogram.ColorPalettePresetNameExtensions.ToValueString(value.Value));
+            }
+        }
+    }
+}

--- a/src/libs/Ideogram/Generated/JsonConverters.ColorPaletteWithPresetNameOrMembers.g.cs
+++ b/src/libs/Ideogram/Generated/JsonConverters.ColorPaletteWithPresetNameOrMembers.g.cs
@@ -1,0 +1,86 @@
+#nullable enable
+#pragma warning disable CS0618 // Type or member is obsolete
+
+namespace Ideogram.JsonConverters
+{
+    /// <inheritdoc />
+    public class ColorPaletteWithPresetNameOrMembersJsonConverter : global::System.Text.Json.Serialization.JsonConverter<global::Ideogram.ColorPaletteWithPresetNameOrMembers>
+    {
+        /// <inheritdoc />
+        public override global::Ideogram.ColorPaletteWithPresetNameOrMembers Read(
+            ref global::System.Text.Json.Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            options = options ?? throw new global::System.ArgumentNullException(nameof(options));
+            var typeInfoResolver = options.TypeInfoResolver ?? throw new global::System.InvalidOperationException("TypeInfoResolver is not set.");
+
+            var
+            readerCopy = reader;
+            global::Ideogram.ColorPaletteWithPresetName?  = default;
+            try
+            {
+                var typeInfo = typeInfoResolver.GetTypeInfo(typeof(global::Ideogram.ColorPaletteWithPresetName), options) as global::System.Text.Json.Serialization.Metadata.JsonTypeInfo<global::Ideogram.ColorPaletteWithPresetName> ??
+                               throw new global::System.InvalidOperationException($"Cannot get type info for {typeof(global::Ideogram.ColorPaletteWithPresetName).Name}");
+                 = global::System.Text.Json.JsonSerializer.Deserialize(ref readerCopy, typeInfo);
+            }
+            catch (global::System.Text.Json.JsonException)
+            {
+            }
+
+            readerCopy = reader;
+            global::Ideogram.ColorPaletteWithMembers?  = default;
+            try
+            {
+                var typeInfo = typeInfoResolver.GetTypeInfo(typeof(global::Ideogram.ColorPaletteWithMembers), options) as global::System.Text.Json.Serialization.Metadata.JsonTypeInfo<global::Ideogram.ColorPaletteWithMembers> ??
+                               throw new global::System.InvalidOperationException($"Cannot get type info for {typeof(global::Ideogram.ColorPaletteWithMembers).Name}");
+                 = global::System.Text.Json.JsonSerializer.Deserialize(ref readerCopy, typeInfo);
+            }
+            catch (global::System.Text.Json.JsonException)
+            {
+            }
+
+            var result = new global::Ideogram.ColorPaletteWithPresetNameOrMembers(
+                ,
+                );
+
+            if ( != null)
+            {
+                var typeInfo = typeInfoResolver.GetTypeInfo(typeof(global::Ideogram.ColorPaletteWithPresetName), options) as global::System.Text.Json.Serialization.Metadata.JsonTypeInfo<global::Ideogram.ColorPaletteWithPresetName> ??
+                               throw new global::System.InvalidOperationException($"Cannot get type info for {typeof(global::Ideogram.ColorPaletteWithPresetName).Name}");
+                _ = global::System.Text.Json.JsonSerializer.Deserialize(ref reader, typeInfo);
+            }
+            else if ( != null)
+            {
+                var typeInfo = typeInfoResolver.GetTypeInfo(typeof(global::Ideogram.ColorPaletteWithMembers), options) as global::System.Text.Json.Serialization.Metadata.JsonTypeInfo<global::Ideogram.ColorPaletteWithMembers> ??
+                               throw new global::System.InvalidOperationException($"Cannot get type info for {typeof(global::Ideogram.ColorPaletteWithMembers).Name}");
+                _ = global::System.Text.Json.JsonSerializer.Deserialize(ref reader, typeInfo);
+            }
+
+            return result;
+        }
+
+        /// <inheritdoc />
+        public override void Write(
+            global::System.Text.Json.Utf8JsonWriter writer,
+            global::Ideogram.ColorPaletteWithPresetNameOrMembers value,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            options = options ?? throw new global::System.ArgumentNullException(nameof(options));
+            var typeInfoResolver = options.TypeInfoResolver ?? throw new global::System.InvalidOperationException("TypeInfoResolver is not set.");
+
+            if (value.Is)
+            {
+                var typeInfo = typeInfoResolver.GetTypeInfo(typeof(global::Ideogram.ColorPaletteWithPresetName), options) as global::System.Text.Json.Serialization.Metadata.JsonTypeInfo<global::Ideogram.ColorPaletteWithPresetName?> ??
+                               throw new global::System.InvalidOperationException($"Cannot get type info for {typeof(global::Ideogram.ColorPaletteWithPresetName).Name}");
+                global::System.Text.Json.JsonSerializer.Serialize(writer, value., typeInfo);
+            }
+            else if (value.Is)
+            {
+                var typeInfo = typeInfoResolver.GetTypeInfo(typeof(global::Ideogram.ColorPaletteWithMembers), options) as global::System.Text.Json.Serialization.Metadata.JsonTypeInfo<global::Ideogram.ColorPaletteWithMembers?> ??
+                               throw new global::System.InvalidOperationException($"Cannot get type info for {typeof(global::Ideogram.ColorPaletteWithMembers).Name}");
+                global::System.Text.Json.JsonSerializer.Serialize(writer, value., typeInfo);
+            }
+        }
+    }
+}

--- a/src/libs/Ideogram/Generated/JsonSerializerContext.g.cs
+++ b/src/libs/Ideogram/Generated/JsonSerializerContext.g.cs
@@ -23,6 +23,9 @@ namespace Ideogram
             typeof(global::Ideogram.JsonConverters.StyleTypeNullableJsonConverter),
             typeof(global::Ideogram.JsonConverters.ResolutionJsonConverter),
             typeof(global::Ideogram.JsonConverters.ResolutionNullableJsonConverter),
+            typeof(global::Ideogram.JsonConverters.ColorPalettePresetNameJsonConverter),
+            typeof(global::Ideogram.JsonConverters.ColorPalettePresetNameNullableJsonConverter),
+            typeof(global::Ideogram.JsonConverters.ColorPaletteWithPresetNameOrMembersJsonConverter),
         })]
 
     [global::System.Text.Json.Serialization.JsonSerializable(typeof(global::Ideogram.JsonSerializerContextTypes))]

--- a/src/libs/Ideogram/Generated/JsonSerializerContextTypes.g.cs
+++ b/src/libs/Ideogram/Generated/JsonSerializerContextTypes.g.cs
@@ -69,122 +69,146 @@ namespace Ideogram
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.RemixImageRequest? Type14 { get; set; }
+        public global::Ideogram.ColorPaletteWithPresetNameOrMembers? Type14 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.UpscaleImageRequest? Type15 { get; set; }
+        public global::Ideogram.ColorPaletteWithPresetName? Type15 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.UpscaleInitialImageRequest? Type16 { get; set; }
+        public global::Ideogram.ColorPalettePresetName? Type16 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.InitialImageRequest? Type17 { get; set; }
+        public global::Ideogram.ColorPaletteWithMembers? Type17 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.GenerateImageResponse? Type18 { get; set; }
+        public global::System.Collections.Generic.IList<global::Ideogram.ColorPaletteMember>? Type18 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.DateTime? Type19 { get; set; }
+        public global::Ideogram.ColorPaletteMember? Type19 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Ideogram.ImageObject>? Type20 { get; set; }
+        public double? Type20 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.ImageObject? Type21 { get; set; }
+        public global::Ideogram.RemixImageRequest? Type21 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public bool? Type22 { get; set; }
+        public global::Ideogram.UpscaleImageRequest? Type22 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.GenerateImageSafetyError? Type23 { get; set; }
+        public global::Ideogram.UpscaleInitialImageRequest? Type23 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.ImageSafetyError? Type24 { get; set; }
+        public global::Ideogram.InitialImageRequest? Type24 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.ManageApiSubscriptionResponse? Type25 { get; set; }
+        public global::Ideogram.GenerateImageResponse? Type25 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.MetronomeLinks? Type26 { get; set; }
+        public global::System.DateTime? Type26 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.RechargeSettings? Type27 { get; set; }
+        public global::System.Collections.Generic.IList<global::Ideogram.ImageObject>? Type27 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.Price? Type28 { get; set; }
+        public global::Ideogram.ImageObject? Type28 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public double? Type29 { get; set; }
+        public bool? Type29 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.RechargeSettingsResponse? Type30 { get; set; }
+        public global::Ideogram.GenerateImageSafetyError? Type30 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.PostApiSubscriptionResponse? Type31 { get; set; }
+        public global::Ideogram.ImageSafetyError? Type31 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.PostApiSubscriptionError? Type32 { get; set; }
+        public global::Ideogram.ManageApiSubscriptionResponse? Type32 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<string>? Type33 { get; set; }
+        public global::Ideogram.MetronomeLinks? Type33 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.PostApiSubscriptionRequest? Type34 { get; set; }
+        public global::Ideogram.RechargeSettings? Type34 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.PostApiReactivateResponse? Type35 { get; set; }
+        public global::Ideogram.Price? Type35 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.GetApiKeysResponse? Type36 { get; set; }
+        public global::Ideogram.RechargeSettingsResponse? Type36 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Ideogram.RedactedApiKey>? Type37 { get; set; }
+        public global::Ideogram.PostApiSubscriptionResponse? Type37 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.RedactedApiKey? Type38 { get; set; }
+        public global::Ideogram.PostApiSubscriptionError? Type38 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.PostApiKeyResponse? Type39 { get; set; }
+        public global::System.Collections.Generic.IList<string>? Type39 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.ManageApiStripeSubscriptionResponse? Type40 { get; set; }
+        public global::Ideogram.PostApiSubscriptionRequest? Type40 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.GetApiTermsResponse? Type41 { get; set; }
+        public global::Ideogram.PostApiReactivateResponse? Type41 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.ApiTerms? Type42 { get; set; }
+        public global::Ideogram.GetApiKeysResponse? Type42 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.PostApiTermsRequest? Type43 { get; set; }
+        public global::System.Collections.Generic.IList<global::Ideogram.RedactedApiKey>? Type43 { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public global::Ideogram.RedactedApiKey? Type44 { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public global::Ideogram.PostApiKeyResponse? Type45 { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public global::Ideogram.ManageApiStripeSubscriptionResponse? Type46 { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public global::Ideogram.GetApiTermsResponse? Type47 { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public global::Ideogram.ApiTerms? Type48 { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public global::Ideogram.PostApiTermsRequest? Type49 { get; set; }
     }
 }

--- a/src/libs/Ideogram/openapi.yaml
+++ b/src/libs/Ideogram/openapi.yaml
@@ -453,6 +453,8 @@ components:
           example: 'brush strokes, painting'
         resolution:
           $ref: '#/components/schemas/Resolution'
+        color_palette:
+          $ref: '#/components/schemas/ColorPaletteWithPresetNameOrMembers'
       example:
         aspect_ratio: ASPECT_10_16
         magic_prompt_option: AUTO
@@ -1040,6 +1042,78 @@ components:
       type: string
       description: '(For model_version for 2.0 only, cannot be used in conjunction with aspect_ratio) The resolution to use for image generation, represented in width x height. If not specified, defaults to using aspect_ratio.'
       example: RESOLUTION_1024_1024
+    ColorPaletteWithPresetNameOrMembers:
+      title: ColorPaletteWithPresetNameOrMembers
+      oneOf:
+        - $ref: '#/components/schemas/ColorPaletteWithPresetName'
+        - $ref: '#/components/schemas/ColorPaletteWithMembers'
+      description: 'A color palette for generation, must EITHER be specified via one of the presets (name) or explicitly via hexadecimal representations of the color with optional weights (members).'
+    ColorPaletteWithPresetName:
+      title: ColorPaletteWithPresetName
+      required:
+        - name
+      type: object
+      properties:
+        name:
+          $ref: '#/components/schemas/ColorPalettePresetName'
+    ColorPalettePresetName:
+      title: ColorPalettePresetName
+      enum:
+        - EMBER
+        - FRESH
+        - JUNGLE
+        - MAGIC
+        - MELON
+        - MOSAIC
+        - PASTEL
+        - ULTRAMARINE
+      type: string
+      description: A color palette preset value
+      example: PASTEL
+    ColorPaletteWithMembers:
+      title: ColorPaletteWithMembers
+      required:
+        - members
+      type: object
+      properties:
+        members:
+          title: ColorPaletteMembers
+          maxItems: 10
+          minItems: 1
+          type: array
+          items:
+            $ref: '#/components/schemas/ColorPaletteMember'
+          description: A list of ColorPaletteMembers that define the color palette.
+      description: A color palette represented only via its members
+    ColorPaletteMembers:
+      title: ColorPaletteMembers
+      maxItems: 10
+      minItems: 1
+      type: array
+      items:
+        $ref: '#/components/schemas/ColorPaletteMember'
+      description: A list of ColorPaletteMembers that define the color palette.
+    ColorPaletteMember:
+      title: ColorPaletteMember
+      required:
+        - color_hex
+        - color_weight
+      type: object
+      properties:
+        color_hex:
+          title: color_hex
+          pattern: '^#(?:[0-9a-fA-F]{3}){1,2}$'
+          type: string
+          description: The hexadecimal representation of the color with an optional chosen weight
+          example: '#FFFFFF'
+        color_weight:
+          title: color_weight
+          maximum: 1.0
+          minimum: 0.05
+          type: number
+          description: The weight of the color in the color palette.
+          example: 0.25
+      description: A member of a color palette.
     Price:
       title: Price
       required:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced multiple classes for managing color palettes, including `ColorPaletteMember`, `ColorPaletteWithMembers`, and `ColorPaletteWithPresetName`.
  - Added support for color palette specifications through both predefined presets and explicit color definitions in image requests.
  - Enhanced JSON serialization capabilities for new color palette types.

- **Documentation**
  - Updated OpenAPI schema to include `color_palette` property and new schemas for color palette management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->