### PR TITLE
feat:Update OpenAPI specification for Ideogram API endpoints and schema

### DIFF
--- a/src/libs/Ideogram/Generated/Ideogram.GenerateClient.PostEditImage.g.cs
+++ b/src/libs/Ideogram/Generated/Ideogram.GenerateClient.PostEditImage.g.cs
@@ -25,7 +25,8 @@ namespace Ideogram
         /// Edit<br/>
         /// Edit a given image synchronously using the provided mask. The mask indicates which part of the image<br/>
         /// should be edited, while the prompt and chosen style type can further guide the edit.<br/>
-        /// Supported image formats include JPEG, PNG, and WEBP
+        /// Supported image formats include JPEG, PNG, and WEBP.<br/>
+        /// Images links are available for a limited period of time; if you would like to keep the image, you must download it.
         /// </summary>
         /// <param name="request"></param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>
@@ -161,7 +162,8 @@ namespace Ideogram
         /// Edit<br/>
         /// Edit a given image synchronously using the provided mask. The mask indicates which part of the image<br/>
         /// should be edited, while the prompt and chosen style type can further guide the edit.<br/>
-        /// Supported image formats include JPEG, PNG, and WEBP
+        /// Supported image formats include JPEG, PNG, and WEBP.<br/>
+        /// Images links are available for a limited period of time; if you would like to keep the image, you must download it.
         /// </summary>
         /// <param name="imageFile">
         /// The image being edited; only JPEG, WEBPs and PNGs are supported at this time

--- a/src/libs/Ideogram/Generated/Ideogram.GenerateClient.PostGenerateImage.g.cs
+++ b/src/libs/Ideogram/Generated/Ideogram.GenerateClient.PostGenerateImage.g.cs
@@ -23,7 +23,8 @@ namespace Ideogram
 
         /// <summary>
         /// Generate<br/>
-        /// Generates images synchronously based on a given prompt and optional parameters.
+        /// Generates images synchronously based on a given prompt and optional parameters.<br/>
+        /// Images links are available for a limited period of time; if you would like to keep the image, you must download it.
         /// </summary>
         /// <param name="request"></param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>
@@ -117,7 +118,8 @@ namespace Ideogram
 
         /// <summary>
         /// Generate<br/>
-        /// Generates images synchronously based on a given prompt and optional parameters.
+        /// Generates images synchronously based on a given prompt and optional parameters.<br/>
+        /// Images links are available for a limited period of time; if you would like to keep the image, you must download it.
         /// </summary>
         /// <param name="imageRequest"></param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>

--- a/src/libs/Ideogram/Generated/Ideogram.GenerateClient.PostRemixImage.g.cs
+++ b/src/libs/Ideogram/Generated/Ideogram.GenerateClient.PostRemixImage.g.cs
@@ -25,7 +25,8 @@ namespace Ideogram
         /// Remix<br/>
         /// Remix provided images synchronously based on a given prompt and optional parameters<br/>
         /// Input images are cropped to the chosen aspect ratio before being remixed.<br/>
-        /// Supported image formats include JPEG, PNG, and WEBP
+        /// Supported image formats include JPEG, PNG, and WEBP.<br/>
+        /// Images links are available for a limited period of time; if you would like to keep the image, you must download it.
         /// </summary>
         /// <param name="request"></param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>
@@ -130,7 +131,8 @@ namespace Ideogram
         /// Remix<br/>
         /// Remix provided images synchronously based on a given prompt and optional parameters<br/>
         /// Input images are cropped to the chosen aspect ratio before being remixed.<br/>
-        /// Supported image formats include JPEG, PNG, and WEBP
+        /// Supported image formats include JPEG, PNG, and WEBP.<br/>
+        /// Images links are available for a limited period of time; if you would like to keep the image, you must download it.
         /// </summary>
         /// <param name="imageRequest">
         /// A request to generate a new image using a provided image and a prompt.

--- a/src/libs/Ideogram/Generated/Ideogram.GenerateClient.PostUpscaleImage.g.cs
+++ b/src/libs/Ideogram/Generated/Ideogram.GenerateClient.PostUpscaleImage.g.cs
@@ -24,7 +24,8 @@ namespace Ideogram
         /// <summary>
         /// Upscale<br/>
         /// Upscale provided images synchronously with an optional prompt.<br/>
-        /// Supported image formats include JPEG, PNG, and WEBP
+        /// Supported image formats include JPEG, PNG, and WEBP.<br/>
+        /// Images links are available for a limited period of time; if you would like to keep the image, you must download it.
         /// </summary>
         /// <param name="request"></param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>
@@ -128,7 +129,8 @@ namespace Ideogram
         /// <summary>
         /// Upscale<br/>
         /// Upscale provided images synchronously with an optional prompt.<br/>
-        /// Supported image formats include JPEG, PNG, and WEBP
+        /// Supported image formats include JPEG, PNG, and WEBP.<br/>
+        /// Images links are available for a limited period of time; if you would like to keep the image, you must download it.
         /// </summary>
         /// <param name="imageRequest">
         /// A request to upscale a provided image with the help of an optional prompt.

--- a/src/libs/Ideogram/Generated/Ideogram.IGenerateClient.PostEditImage.g.cs
+++ b/src/libs/Ideogram/Generated/Ideogram.IGenerateClient.PostEditImage.g.cs
@@ -8,7 +8,8 @@ namespace Ideogram
         /// Edit<br/>
         /// Edit a given image synchronously using the provided mask. The mask indicates which part of the image<br/>
         /// should be edited, while the prompt and chosen style type can further guide the edit.<br/>
-        /// Supported image formats include JPEG, PNG, and WEBP
+        /// Supported image formats include JPEG, PNG, and WEBP.<br/>
+        /// Images links are available for a limited period of time; if you would like to keep the image, you must download it.
         /// </summary>
         /// <param name="request"></param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>
@@ -21,7 +22,8 @@ namespace Ideogram
         /// Edit<br/>
         /// Edit a given image synchronously using the provided mask. The mask indicates which part of the image<br/>
         /// should be edited, while the prompt and chosen style type can further guide the edit.<br/>
-        /// Supported image formats include JPEG, PNG, and WEBP
+        /// Supported image formats include JPEG, PNG, and WEBP.<br/>
+        /// Images links are available for a limited period of time; if you would like to keep the image, you must download it.
         /// </summary>
         /// <param name="imageFile">
         /// The image being edited; only JPEG, WEBPs and PNGs are supported at this time

--- a/src/libs/Ideogram/Generated/Ideogram.IGenerateClient.PostGenerateImage.g.cs
+++ b/src/libs/Ideogram/Generated/Ideogram.IGenerateClient.PostGenerateImage.g.cs
@@ -6,7 +6,8 @@ namespace Ideogram
     {
         /// <summary>
         /// Generate<br/>
-        /// Generates images synchronously based on a given prompt and optional parameters.
+        /// Generates images synchronously based on a given prompt and optional parameters.<br/>
+        /// Images links are available for a limited period of time; if you would like to keep the image, you must download it.
         /// </summary>
         /// <param name="request"></param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>
@@ -17,7 +18,8 @@ namespace Ideogram
 
         /// <summary>
         /// Generate<br/>
-        /// Generates images synchronously based on a given prompt and optional parameters.
+        /// Generates images synchronously based on a given prompt and optional parameters.<br/>
+        /// Images links are available for a limited period of time; if you would like to keep the image, you must download it.
         /// </summary>
         /// <param name="imageRequest"></param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>

--- a/src/libs/Ideogram/Generated/Ideogram.IGenerateClient.PostRemixImage.g.cs
+++ b/src/libs/Ideogram/Generated/Ideogram.IGenerateClient.PostRemixImage.g.cs
@@ -8,7 +8,8 @@ namespace Ideogram
         /// Remix<br/>
         /// Remix provided images synchronously based on a given prompt and optional parameters<br/>
         /// Input images are cropped to the chosen aspect ratio before being remixed.<br/>
-        /// Supported image formats include JPEG, PNG, and WEBP
+        /// Supported image formats include JPEG, PNG, and WEBP.<br/>
+        /// Images links are available for a limited period of time; if you would like to keep the image, you must download it.
         /// </summary>
         /// <param name="request"></param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>
@@ -21,7 +22,8 @@ namespace Ideogram
         /// Remix<br/>
         /// Remix provided images synchronously based on a given prompt and optional parameters<br/>
         /// Input images are cropped to the chosen aspect ratio before being remixed.<br/>
-        /// Supported image formats include JPEG, PNG, and WEBP
+        /// Supported image formats include JPEG, PNG, and WEBP.<br/>
+        /// Images links are available for a limited period of time; if you would like to keep the image, you must download it.
         /// </summary>
         /// <param name="imageRequest">
         /// A request to generate a new image using a provided image and a prompt.

--- a/src/libs/Ideogram/Generated/Ideogram.IGenerateClient.PostUpscaleImage.g.cs
+++ b/src/libs/Ideogram/Generated/Ideogram.IGenerateClient.PostUpscaleImage.g.cs
@@ -7,7 +7,8 @@ namespace Ideogram
         /// <summary>
         /// Upscale<br/>
         /// Upscale provided images synchronously with an optional prompt.<br/>
-        /// Supported image formats include JPEG, PNG, and WEBP
+        /// Supported image formats include JPEG, PNG, and WEBP.<br/>
+        /// Images links are available for a limited period of time; if you would like to keep the image, you must download it.
         /// </summary>
         /// <param name="request"></param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>
@@ -19,7 +20,8 @@ namespace Ideogram
         /// <summary>
         /// Upscale<br/>
         /// Upscale provided images synchronously with an optional prompt.<br/>
-        /// Supported image formats include JPEG, PNG, and WEBP
+        /// Supported image formats include JPEG, PNG, and WEBP.<br/>
+        /// Images links are available for a limited period of time; if you would like to keep the image, you must download it.
         /// </summary>
         /// <param name="imageRequest">
         /// A request to upscale a provided image with the help of an optional prompt.

--- a/src/libs/Ideogram/Generated/Ideogram.Models.GenerateImageResponse.g.cs
+++ b/src/libs/Ideogram/Generated/Ideogram.Models.GenerateImageResponse.g.cs
@@ -4,7 +4,8 @@
 namespace Ideogram
 {
     /// <summary>
-    /// 
+    /// The response which contains information about the generated image, including the download link.<br/>
+    /// Images links are available for a limited period of time; if you would like to keep the image, you must download it.
     /// </summary>
     public sealed partial class GenerateImageResponse
     {

--- a/src/libs/Ideogram/openapi.yaml
+++ b/src/libs/Ideogram/openapi.yaml
@@ -42,7 +42,7 @@ paths:
       tags:
         - generate
       summary: Edit
-      description: "Edit a given image synchronously using the provided mask. The mask indicates which part of the image\nshould be edited, while the prompt and chosen style type can further guide the edit.\n\nSupported image formats include JPEG, PNG, and WEBP\n"
+      description: "Edit a given image synchronously using the provided mask. The mask indicates which part of the image\nshould be edited, while the prompt and chosen style type can further guide the edit.\n\nSupported image formats include JPEG, PNG, and WEBP.\n\nImages links are available for a limited period of time; if you would like to keep the image, you must download it.\n"
       operationId: post_edit_image
       requestBody:
         description: A request to edit an image with Ideogram.
@@ -93,7 +93,7 @@ paths:
       tags:
         - generate
       summary: Generate
-      description: "Generates images synchronously based on a given prompt and optional parameters.\n"
+      description: "Generates images synchronously based on a given prompt and optional parameters.\n\nImages links are available for a limited period of time; if you would like to keep the image, you must download it.\n"
       operationId: post_generate_image
       requestBody:
         description: A request to generate an image with Ideogram.
@@ -372,7 +372,7 @@ paths:
       tags:
         - generate
       summary: Remix
-      description: "Remix provided images synchronously based on a given prompt and optional parameters\n\nInput images are cropped to the chosen aspect ratio before being remixed.\n\nSupported image formats include JPEG, PNG, and WEBP\n"
+      description: "Remix provided images synchronously based on a given prompt and optional parameters\n\nInput images are cropped to the chosen aspect ratio before being remixed.\n\nSupported image formats include JPEG, PNG, and WEBP.\n\nImages links are available for a limited period of time; if you would like to keep the image, you must download it.\n"
       operationId: post_remix_image
       requestBody:
         description: A request to remix a provided image with Ideogram. Input images are cropped to the chosen aspect ratio before being remixed.
@@ -410,7 +410,7 @@ paths:
       tags:
         - generate
       summary: Upscale
-      description: "Upscale provided images synchronously with an optional prompt.\n\nSupported image formats include JPEG, PNG, and WEBP\n"
+      description: "Upscale provided images synchronously with an optional prompt.\n\nSupported image formats include JPEG, PNG, and WEBP.\n\nImages links are available for a limited period of time; if you would like to keep the image, you must download it.\n"
       operationId: post_upscale_image
       requestBody:
         description: A request to upscale a provided image with Ideogram.
@@ -711,6 +711,7 @@ components:
           items:
             $ref: '#/components/schemas/ImageObject'
           description: A list of ImageObjects that contain the generated image(s).
+      description: "The response which contains information about the generated image, including the download link.\nImages links are available for a limited period of time; if you would like to keep the image, you must download it."
       example:
         data:
           - style_type: REALISTIC


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced descriptions for the `/edit`, `/generate`, `/remix`, and `/upscale` API endpoints, clarifying the temporary availability of image links.
	- Updated `GenerateImageResponse` schema to include details about the need for users to download images promptly.

- **Documentation**
	- Improved clarity and completeness of API documentation regarding the lifecycle of generated images and user responsibilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->