### PR TITLE
feat:Update OpenAPI Specification for Ideogram API with New Properties and Schemas

### DIFF
--- a/src/libs/Ideogram/Generated/Ideogram.GenerateClient.PostEditImage.g.cs
+++ b/src/libs/Ideogram/Generated/Ideogram.GenerateClient.PostEditImage.g.cs
@@ -91,6 +91,12 @@ namespace Ideogram
                     content: new global::System.Net.Http.StringContent($"{request.MagicPromptOption?.ToValueString()}"),
                     name: "magic_prompt_option");
             } 
+            if (request.NumImages != default)
+            {
+                __httpRequestContent.Add(
+                    content: new global::System.Net.Http.StringContent($"{request.NumImages}"),
+                    name: "num_images");
+            } 
             if (request.Seed != default)
             {
                 __httpRequestContent.Add(
@@ -313,13 +319,16 @@ namespace Ideogram
         /// Example: A serene tropical beach scene. Dominating the foreground are tall palm trees with lush green leaves, standing tall against a backdrop of a sandy beach. The beach leads to the azure waters of the sea, which gently kisses the shoreline. In the distance, there is an island or landmass with a silhouette of what appears to be a lighthouse or tower. The sky above is painted with fluffy white clouds, some of which are tinged with hues of pink and orange, suggesting either a sunrise or sunset.
         /// </param>
         /// <param name="model">
-        /// The model used to generate an image or edit one. /generate supports all model types, however, /edit is only supported for V_2 and V_2_TURBO.<br/>
+        /// The model used to generate an image or edit one. /generate and /remix supports all model types, however, /edit is only supported for V_2 and V_2_TURBO.<br/>
         /// Default Value: V_2<br/>
         /// Example: V_2_TURBO
         /// </param>
         /// <param name="magicPromptOption">
         /// Determine if MagicPrompt should be used in generating the request or not<br/>
         /// Example: ON
+        /// </param>
+        /// <param name="numImages">
+        /// Default Value: 1
         /// </param>
         /// <param name="seed">
         /// Example: 12345
@@ -338,6 +347,7 @@ namespace Ideogram
             string prompt,
             global::Ideogram.ModelEnum model,
             global::Ideogram.MagicPromptOption? magicPromptOption = default,
+            int? numImages = default,
             int? seed = default,
             global::Ideogram.StyleType? styleType = default,
             global::System.Threading.CancellationToken cancellationToken = default)
@@ -351,6 +361,7 @@ namespace Ideogram
                 Prompt = prompt,
                 Model = model,
                 MagicPromptOption = magicPromptOption,
+                NumImages = numImages,
                 Seed = seed,
                 StyleType = styleType,
             };

--- a/src/libs/Ideogram/Generated/Ideogram.IGenerateClient.PostEditImage.g.cs
+++ b/src/libs/Ideogram/Generated/Ideogram.IGenerateClient.PostEditImage.g.cs
@@ -42,13 +42,16 @@ namespace Ideogram
         /// Example: A serene tropical beach scene. Dominating the foreground are tall palm trees with lush green leaves, standing tall against a backdrop of a sandy beach. The beach leads to the azure waters of the sea, which gently kisses the shoreline. In the distance, there is an island or landmass with a silhouette of what appears to be a lighthouse or tower. The sky above is painted with fluffy white clouds, some of which are tinged with hues of pink and orange, suggesting either a sunrise or sunset.
         /// </param>
         /// <param name="model">
-        /// The model used to generate an image or edit one. /generate supports all model types, however, /edit is only supported for V_2 and V_2_TURBO.<br/>
+        /// The model used to generate an image or edit one. /generate and /remix supports all model types, however, /edit is only supported for V_2 and V_2_TURBO.<br/>
         /// Default Value: V_2<br/>
         /// Example: V_2_TURBO
         /// </param>
         /// <param name="magicPromptOption">
         /// Determine if MagicPrompt should be used in generating the request or not<br/>
         /// Example: ON
+        /// </param>
+        /// <param name="numImages">
+        /// Default Value: 1
         /// </param>
         /// <param name="seed">
         /// Example: 12345
@@ -67,6 +70,7 @@ namespace Ideogram
             string prompt,
             global::Ideogram.ModelEnum model,
             global::Ideogram.MagicPromptOption? magicPromptOption = default,
+            int? numImages = default,
             int? seed = default,
             global::Ideogram.StyleType? styleType = default,
             global::System.Threading.CancellationToken cancellationToken = default);

--- a/src/libs/Ideogram/Generated/Ideogram.Models.EditImageRequest.g.cs
+++ b/src/libs/Ideogram/Generated/Ideogram.Models.EditImageRequest.g.cs
@@ -46,7 +46,7 @@ namespace Ideogram
         public required string Prompt { get; set; }
 
         /// <summary>
-        /// The model used to generate an image or edit one. /generate supports all model types, however, /edit is only supported for V_2 and V_2_TURBO.<br/>
+        /// The model used to generate an image or edit one. /generate and /remix supports all model types, however, /edit is only supported for V_2 and V_2_TURBO.<br/>
         /// Default Value: V_2<br/>
         /// Example: V_2_TURBO
         /// </summary>
@@ -65,6 +65,12 @@ namespace Ideogram
         [global::System.Text.Json.Serialization.JsonPropertyName("magic_prompt_option")]
         [global::System.Text.Json.Serialization.JsonConverter(typeof(global::Ideogram.JsonConverters.MagicPromptOptionJsonConverter))]
         public global::Ideogram.MagicPromptOption? MagicPromptOption { get; set; }
+
+        /// <summary>
+        /// Default Value: 1
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("num_images")]
+        public int? NumImages { get; set; }
 
         /// <summary>
         /// Example: 12345
@@ -108,13 +114,16 @@ namespace Ideogram
         /// Example: A serene tropical beach scene. Dominating the foreground are tall palm trees with lush green leaves, standing tall against a backdrop of a sandy beach. The beach leads to the azure waters of the sea, which gently kisses the shoreline. In the distance, there is an island or landmass with a silhouette of what appears to be a lighthouse or tower. The sky above is painted with fluffy white clouds, some of which are tinged with hues of pink and orange, suggesting either a sunrise or sunset.
         /// </param>
         /// <param name="model">
-        /// The model used to generate an image or edit one. /generate supports all model types, however, /edit is only supported for V_2 and V_2_TURBO.<br/>
+        /// The model used to generate an image or edit one. /generate and /remix supports all model types, however, /edit is only supported for V_2 and V_2_TURBO.<br/>
         /// Default Value: V_2<br/>
         /// Example: V_2_TURBO
         /// </param>
         /// <param name="magicPromptOption">
         /// Determine if MagicPrompt should be used in generating the request or not<br/>
         /// Example: ON
+        /// </param>
+        /// <param name="numImages">
+        /// Default Value: 1
         /// </param>
         /// <param name="seed">
         /// Example: 12345
@@ -132,6 +141,7 @@ namespace Ideogram
             string prompt,
             global::Ideogram.ModelEnum model,
             global::Ideogram.MagicPromptOption? magicPromptOption,
+            int? numImages,
             int? seed,
             global::Ideogram.StyleType? styleType)
         {
@@ -142,6 +152,7 @@ namespace Ideogram
             this.Prompt = prompt ?? throw new global::System.ArgumentNullException(nameof(prompt));
             this.Model = model;
             this.MagicPromptOption = magicPromptOption;
+            this.NumImages = numImages;
             this.Seed = seed;
             this.StyleType = styleType;
         }

--- a/src/libs/Ideogram/Generated/Ideogram.Models.ImageRequest.g.cs
+++ b/src/libs/Ideogram/Generated/Ideogram.Models.ImageRequest.g.cs
@@ -27,7 +27,7 @@ namespace Ideogram
         public global::Ideogram.AspectRatio? AspectRatio { get; set; }
 
         /// <summary>
-        /// The model used to generate an image or edit one. /generate supports all model types, however, /edit is only supported for V_2 and V_2_TURBO.<br/>
+        /// The model used to generate an image or edit one. /generate and /remix supports all model types, however, /edit is only supported for V_2 and V_2_TURBO.<br/>
         /// Default Value: V_2<br/>
         /// Example: V_2_TURBO
         /// </summary>
@@ -70,6 +70,12 @@ namespace Ideogram
         public string? NegativePrompt { get; set; }
 
         /// <summary>
+        /// Default Value: 1
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("num_images")]
+        public int? NumImages { get; set; }
+
+        /// <summary>
         /// (For model_version for 2.0 only, cannot be used in conjunction with aspect_ratio) The resolution to use for image generation, represented in width x height. If not specified, defaults to using aspect_ratio.<br/>
         /// Example: RESOLUTION_1024_1024
         /// </summary>
@@ -103,7 +109,7 @@ namespace Ideogram
         /// Example: ASPECT_10_16
         /// </param>
         /// <param name="model">
-        /// The model used to generate an image or edit one. /generate supports all model types, however, /edit is only supported for V_2 and V_2_TURBO.<br/>
+        /// The model used to generate an image or edit one. /generate and /remix supports all model types, however, /edit is only supported for V_2 and V_2_TURBO.<br/>
         /// Default Value: V_2<br/>
         /// Example: V_2_TURBO
         /// </param>
@@ -122,6 +128,9 @@ namespace Ideogram
         /// Description of what to exclude from an image. Descriptions in the prompt take precedence to descriptions in the negative prompt.<br/>
         /// Example: brush strokes, painting
         /// </param>
+        /// <param name="numImages">
+        /// Default Value: 1
+        /// </param>
         /// <param name="resolution">
         /// (For model_version for 2.0 only, cannot be used in conjunction with aspect_ratio) The resolution to use for image generation, represented in width x height. If not specified, defaults to using aspect_ratio.<br/>
         /// Example: RESOLUTION_1024_1024
@@ -138,6 +147,7 @@ namespace Ideogram
             int? seed,
             global::Ideogram.StyleType? styleType,
             string? negativePrompt,
+            int? numImages,
             global::Ideogram.Resolution? resolution,
             global::Ideogram.ColorPaletteWithPresetNameOrMembers? colorPalette)
         {
@@ -148,6 +158,7 @@ namespace Ideogram
             this.Seed = seed;
             this.StyleType = styleType;
             this.NegativePrompt = negativePrompt;
+            this.NumImages = numImages;
             this.Resolution = resolution;
             this.ColorPalette = colorPalette;
         }

--- a/src/libs/Ideogram/Generated/Ideogram.Models.ModelEnum.g.cs
+++ b/src/libs/Ideogram/Generated/Ideogram.Models.ModelEnum.g.cs
@@ -4,7 +4,7 @@
 namespace Ideogram
 {
     /// <summary>
-    /// The model used to generate an image or edit one. /generate supports all model types, however, /edit is only supported for V_2 and V_2_TURBO.<br/>
+    /// The model used to generate an image or edit one. /generate and /remix supports all model types, however, /edit is only supported for V_2 and V_2_TURBO.<br/>
     /// Default Value: V_2<br/>
     /// Example: V_2_TURBO
     /// </summary>
@@ -26,6 +26,14 @@ namespace Ideogram
         /// 
         /// </summary>
         V2TURBO,
+        /// <summary>
+        /// 
+        /// </summary>
+        V21,
+        /// <summary>
+        /// 
+        /// </summary>
+        V21TURBO,
     }
 
     /// <summary>
@@ -44,6 +52,8 @@ namespace Ideogram
                 ModelEnum.V1TURBO => "V_1_TURBO",
                 ModelEnum.V2 => "V_2",
                 ModelEnum.V2TURBO => "V_2_TURBO",
+                ModelEnum.V21 => "V_2_1",
+                ModelEnum.V21TURBO => "V_2_1_TURBO",
                 _ => throw new global::System.ArgumentOutOfRangeException(nameof(value), value, null),
             };
         }
@@ -58,6 +68,8 @@ namespace Ideogram
                 "V_1_TURBO" => ModelEnum.V1TURBO,
                 "V_2" => ModelEnum.V2,
                 "V_2_TURBO" => ModelEnum.V2TURBO,
+                "V_2_1" => ModelEnum.V21,
+                "V_2_1_TURBO" => ModelEnum.V21TURBO,
                 _ => null,
             };
         }

--- a/src/libs/Ideogram/Generated/Ideogram.Models.UpscaleInitialImageRequest.g.cs
+++ b/src/libs/Ideogram/Generated/Ideogram.Models.UpscaleInitialImageRequest.g.cs
@@ -42,6 +42,12 @@ namespace Ideogram
         public global::Ideogram.MagicPromptOption? MagicPromptOption { get; set; }
 
         /// <summary>
+        /// Default Value: 1
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("num_images")]
+        public int? NumImages { get; set; }
+
+        /// <summary>
         /// Example: 12345
         /// </summary>
         /// <example>12345</example>
@@ -73,6 +79,9 @@ namespace Ideogram
         /// Determine if MagicPrompt should be used in generating the request or not<br/>
         /// Example: ON
         /// </param>
+        /// <param name="numImages">
+        /// Default Value: 1
+        /// </param>
         /// <param name="seed">
         /// Example: 12345
         /// </param>
@@ -82,12 +91,14 @@ namespace Ideogram
             int? resemblance,
             int? detail,
             global::Ideogram.MagicPromptOption? magicPromptOption,
+            int? numImages,
             int? seed)
         {
             this.Prompt = prompt;
             this.Resemblance = resemblance;
             this.Detail = detail;
             this.MagicPromptOption = magicPromptOption;
+            this.NumImages = numImages;
             this.Seed = seed;
         }
 

--- a/src/libs/Ideogram/openapi.yaml
+++ b/src/libs/Ideogram/openapi.yaml
@@ -506,6 +506,8 @@ components:
           $ref: '#/components/schemas/ModelEnum'
         magic_prompt_option:
           $ref: '#/components/schemas/MagicPromptOption'
+        num_images:
+          $ref: '#/components/schemas/NumImages'
         seed:
           $ref: '#/components/schemas/Seed'
         style_type:
@@ -646,6 +648,12 @@ components:
           type: string
           description: Description of what to exclude from an image. Descriptions in the prompt take precedence to descriptions in the negative prompt.
           example: 'brush strokes, painting'
+        num_images:
+          title: num_images
+          maximum: 8
+          minimum: 1
+          type: integer
+          default: 1
         resolution:
           $ref: '#/components/schemas/Resolution'
         color_palette:
@@ -699,6 +707,12 @@ components:
           example: 50
         magic_prompt_option:
           $ref: '#/components/schemas/MagicPromptOption'
+        num_images:
+          title: num_images
+          maximum: 8
+          minimum: 1
+          type: integer
+          default: 1
         seed:
           title: Seed
           maximum: 2147483647
@@ -792,8 +806,10 @@ components:
         - V_1_TURBO
         - V_2
         - V_2_TURBO
+        - V_2_1
+        - V_2_1_TURBO
       type: string
-      description: 'The model used to generate an image or edit one. /generate supports all model types, however, /edit is only supported for V_2 and V_2_TURBO.'
+      description: 'The model used to generate an image or edit one. /generate and /remix supports all model types, however, /edit is only supported for V_2 and V_2_TURBO.'
       default: V_2
       example: V_2_TURBO
     GenerateImageSafetyError:
@@ -1121,6 +1137,12 @@ components:
       externalDocs:
         url: https://docs.ideogram.ai/using-ideogram/ideogram-features/magic-prompt
       example: ON
+    NumImages:
+      title: num_images
+      maximum: 8
+      minimum: 1
+      type: integer
+      default: 1
     Seed:
       title: Seed
       maximum: 2147483647


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Users can now specify the number of images to generate or edit in a single request, with options ranging from 1 to 8.
	- Two new model types, `V_2_1` and `V_2_1_TURBO`, have been added for enhanced image generation and editing capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->