### PR TITLE
feat:Update OpenAPI spec with model version enum and new rendering speed option

### DIFF
--- a/src/libs/Ideogram/Generated/Ideogram.IVisionClient.PostDescribe.g.cs
+++ b/src/libs/Ideogram/Generated/Ideogram.IVisionClient.PostDescribe.g.cs
@@ -27,11 +27,15 @@ namespace Ideogram
         /// <param name="imageFilename">
         /// An image binary (max size 10MB); only JPEG, WebP and PNG formats are supported at this time.
         /// </param>
+        /// <param name="describeModelVersion">
+        /// The model version to use for describing images. V_2 uses the current describe model, V_3 uses the new captioner model.
+        /// </param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::System.InvalidOperationException"></exception>
         global::System.Threading.Tasks.Task<global::Ideogram.DescribeResponse> PostDescribeAsync(
             byte[] imageFile,
             string imageFilename,
+            global::Ideogram.DescribeModelVersion? describeModelVersion = default,
             global::System.Threading.CancellationToken cancellationToken = default);
     }
 }

--- a/src/libs/Ideogram/Generated/Ideogram.Models.DescribeModelVersion.g.cs
+++ b/src/libs/Ideogram/Generated/Ideogram.Models.DescribeModelVersion.g.cs
@@ -1,0 +1,51 @@
+
+#nullable enable
+
+namespace Ideogram
+{
+    /// <summary>
+    /// The model version to use for describing images. V_2 uses the current describe model, V_3 uses the new captioner model.
+    /// </summary>
+    public enum DescribeModelVersion
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        V2,
+        /// <summary>
+        /// 
+        /// </summary>
+        V3,
+    }
+
+    /// <summary>
+    /// Enum extensions to do fast conversions without the reflection.
+    /// </summary>
+    public static class DescribeModelVersionExtensions
+    {
+        /// <summary>
+        /// Converts an enum to a string.
+        /// </summary>
+        public static string ToValueString(this DescribeModelVersion value)
+        {
+            return value switch
+            {
+                DescribeModelVersion.V2 => "V_2",
+                DescribeModelVersion.V3 => "V_3",
+                _ => throw new global::System.ArgumentOutOfRangeException(nameof(value), value, null),
+            };
+        }
+        /// <summary>
+        /// Converts an string to a enum.
+        /// </summary>
+        public static DescribeModelVersion? ToEnum(string value)
+        {
+            return value switch
+            {
+                "V_2" => DescribeModelVersion.V2,
+                "V_3" => DescribeModelVersion.V3,
+                _ => null,
+            };
+        }
+    }
+}

--- a/src/libs/Ideogram/Generated/Ideogram.Models.DescribeRequest.g.cs
+++ b/src/libs/Ideogram/Generated/Ideogram.Models.DescribeRequest.g.cs
@@ -23,6 +23,13 @@ namespace Ideogram
         public required string ImageFilename { get; set; }
 
         /// <summary>
+        /// The model version to use for describing images. V_2 uses the current describe model, V_3 uses the new captioner model.
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("describe_model_version")]
+        [global::System.Text.Json.Serialization.JsonConverter(typeof(global::Ideogram.JsonConverters.DescribeModelVersionJsonConverter))]
+        public global::Ideogram.DescribeModelVersion? DescribeModelVersion { get; set; }
+
+        /// <summary>
         /// Additional properties that are not explicitly defined in the schema
         /// </summary>
         [global::System.Text.Json.Serialization.JsonExtensionData]
@@ -37,15 +44,20 @@ namespace Ideogram
         /// <param name="imageFilename">
         /// An image binary (max size 10MB); only JPEG, WebP and PNG formats are supported at this time.
         /// </param>
+        /// <param name="describeModelVersion">
+        /// The model version to use for describing images. V_2 uses the current describe model, V_3 uses the new captioner model.
+        /// </param>
 #if NET7_0_OR_GREATER
         [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
 #endif
         public DescribeRequest(
             byte[] imageFile,
-            string imageFilename)
+            string imageFilename,
+            global::Ideogram.DescribeModelVersion? describeModelVersion)
         {
             this.ImageFile = imageFile ?? throw new global::System.ArgumentNullException(nameof(imageFile));
             this.ImageFilename = imageFilename ?? throw new global::System.ArgumentNullException(nameof(imageFilename));
+            this.DescribeModelVersion = describeModelVersion;
         }
 
         /// <summary>

--- a/src/libs/Ideogram/Generated/Ideogram.Models.RenderingSpeed.g.cs
+++ b/src/libs/Ideogram/Generated/Ideogram.Models.RenderingSpeed.g.cs
@@ -12,6 +12,10 @@ namespace Ideogram
         /// <summary>
         /// 
         /// </summary>
+        FLASH,
+        /// <summary>
+        /// 
+        /// </summary>
         TURBO,
         /// <summary>
         /// 
@@ -39,6 +43,7 @@ namespace Ideogram
         {
             return value switch
             {
+                RenderingSpeed.FLASH => "FLASH",
                 RenderingSpeed.TURBO => "TURBO",
                 RenderingSpeed.BALANCED => "BALANCED",
                 RenderingSpeed.DEFAULT => "DEFAULT",
@@ -53,6 +58,7 @@ namespace Ideogram
         {
             return value switch
             {
+                "FLASH" => RenderingSpeed.FLASH,
                 "TURBO" => RenderingSpeed.TURBO,
                 "BALANCED" => RenderingSpeed.BALANCED,
                 "DEFAULT" => RenderingSpeed.DEFAULT,

--- a/src/libs/Ideogram/Generated/Ideogram.VisionClient.PostDescribe.g.cs
+++ b/src/libs/Ideogram/Generated/Ideogram.VisionClient.PostDescribe.g.cs
@@ -73,6 +73,12 @@ namespace Ideogram
                 content: new global::System.Net.Http.ByteArrayContent(request.ImageFile ?? global::System.Array.Empty<byte>()),
                 name: "image_file",
                 fileName: request.ImageFilename ?? string.Empty);
+            if (request.DescribeModelVersion != default)
+            {
+                __httpRequestContent.Add(
+                    content: new global::System.Net.Http.StringContent($"{request.DescribeModelVersion?.ToValueString()}"),
+                    name: "describe_model_version");
+            }
             __httpRequest.Content = __httpRequestContent;
 
             PrepareRequest(
@@ -254,17 +260,22 @@ namespace Ideogram
         /// <param name="imageFilename">
         /// An image binary (max size 10MB); only JPEG, WebP and PNG formats are supported at this time.
         /// </param>
+        /// <param name="describeModelVersion">
+        /// The model version to use for describing images. V_2 uses the current describe model, V_3 uses the new captioner model.
+        /// </param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::System.InvalidOperationException"></exception>
         public async global::System.Threading.Tasks.Task<global::Ideogram.DescribeResponse> PostDescribeAsync(
             byte[] imageFile,
             string imageFilename,
+            global::Ideogram.DescribeModelVersion? describeModelVersion = default,
             global::System.Threading.CancellationToken cancellationToken = default)
         {
             var __request = new global::Ideogram.DescribeRequest
             {
                 ImageFile = imageFile,
                 ImageFilename = imageFilename,
+                DescribeModelVersion = describeModelVersion,
             };
 
             return await PostDescribeAsync(

--- a/src/libs/Ideogram/Generated/JsonConverters.DescribeModelVersion.g.cs
+++ b/src/libs/Ideogram/Generated/JsonConverters.DescribeModelVersion.g.cs
@@ -1,0 +1,53 @@
+#nullable enable
+
+namespace Ideogram.JsonConverters
+{
+    /// <inheritdoc />
+    public sealed class DescribeModelVersionJsonConverter : global::System.Text.Json.Serialization.JsonConverter<global::Ideogram.DescribeModelVersion>
+    {
+        /// <inheritdoc />
+        public override global::Ideogram.DescribeModelVersion Read(
+            ref global::System.Text.Json.Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            switch (reader.TokenType)
+            {
+                case global::System.Text.Json.JsonTokenType.String:
+                {
+                    var stringValue = reader.GetString();
+                    if (stringValue != null)
+                    {
+                        return global::Ideogram.DescribeModelVersionExtensions.ToEnum(stringValue) ?? default;
+                    }
+                    
+                    break;
+                }
+                case global::System.Text.Json.JsonTokenType.Number:
+                {
+                    var numValue = reader.GetInt32();
+                    return (global::Ideogram.DescribeModelVersion)numValue;
+                }
+                case global::System.Text.Json.JsonTokenType.Null:
+                {
+                    return default(global::Ideogram.DescribeModelVersion);
+                }
+                default:
+                    throw new global::System.ArgumentOutOfRangeException(nameof(reader));
+            }
+
+            return default;
+        }
+
+        /// <inheritdoc />
+        public override void Write(
+            global::System.Text.Json.Utf8JsonWriter writer,
+            global::Ideogram.DescribeModelVersion value,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            writer = writer ?? throw new global::System.ArgumentNullException(nameof(writer));
+
+            writer.WriteStringValue(global::Ideogram.DescribeModelVersionExtensions.ToValueString(value));
+        }
+    }
+}

--- a/src/libs/Ideogram/Generated/JsonConverters.DescribeModelVersionNullable.g.cs
+++ b/src/libs/Ideogram/Generated/JsonConverters.DescribeModelVersionNullable.g.cs
@@ -1,0 +1,60 @@
+#nullable enable
+
+namespace Ideogram.JsonConverters
+{
+    /// <inheritdoc />
+    public sealed class DescribeModelVersionNullableJsonConverter : global::System.Text.Json.Serialization.JsonConverter<global::Ideogram.DescribeModelVersion?>
+    {
+        /// <inheritdoc />
+        public override global::Ideogram.DescribeModelVersion? Read(
+            ref global::System.Text.Json.Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            switch (reader.TokenType)
+            {
+                case global::System.Text.Json.JsonTokenType.String:
+                {
+                    var stringValue = reader.GetString();
+                    if (stringValue != null)
+                    {
+                        return global::Ideogram.DescribeModelVersionExtensions.ToEnum(stringValue);
+                    }
+                    
+                    break;
+                }
+                case global::System.Text.Json.JsonTokenType.Number:
+                {
+                    var numValue = reader.GetInt32();
+                    return (global::Ideogram.DescribeModelVersion)numValue;
+                }
+                case global::System.Text.Json.JsonTokenType.Null:
+                {
+                    return default(global::Ideogram.DescribeModelVersion?);
+                }
+                default:
+                    throw new global::System.ArgumentOutOfRangeException(nameof(reader));
+            }
+
+            return default;
+        }
+
+        /// <inheritdoc />
+        public override void Write(
+            global::System.Text.Json.Utf8JsonWriter writer,
+            global::Ideogram.DescribeModelVersion? value,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            writer = writer ?? throw new global::System.ArgumentNullException(nameof(writer));
+
+            if (value == null)
+            {
+                writer.WriteNullValue();
+            }
+            else
+            {
+                writer.WriteStringValue(global::Ideogram.DescribeModelVersionExtensions.ToValueString(value.Value));
+            }
+        }
+    }
+}

--- a/src/libs/Ideogram/Generated/JsonSerializerContext.g.cs
+++ b/src/libs/Ideogram/Generated/JsonSerializerContext.g.cs
@@ -13,6 +13,8 @@ namespace Ideogram
         DefaultIgnoreCondition = global::System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
         Converters = new global::System.Type[] 
         { 
+            typeof(global::Ideogram.JsonConverters.DescribeModelVersionJsonConverter),
+            typeof(global::Ideogram.JsonConverters.DescribeModelVersionNullableJsonConverter),
             typeof(global::Ideogram.JsonConverters.ModelEnumJsonConverter),
             typeof(global::Ideogram.JsonConverters.ModelEnumNullableJsonConverter),
             typeof(global::Ideogram.JsonConverters.MagicPromptOptionJsonConverter),

--- a/src/libs/Ideogram/Generated/JsonSerializerContextTypes.g.cs
+++ b/src/libs/Ideogram/Generated/JsonSerializerContextTypes.g.cs
@@ -50,278 +50,282 @@ namespace Ideogram
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.EditImageRequest? Type6 { get; set; }
+        public global::Ideogram.DescribeModelVersion? Type6 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.ModelEnum? Type7 { get; set; }
+        public global::Ideogram.EditImageRequest? Type7 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.MagicPromptOption? Type8 { get; set; }
+        public global::Ideogram.ModelEnum? Type8 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public int? Type9 { get; set; }
+        public global::Ideogram.MagicPromptOption? Type9 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.StyleType? Type10 { get; set; }
+        public int? Type10 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.GenerateImageRequest? Type11 { get; set; }
+        public global::Ideogram.StyleType? Type11 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.ImageRequest? Type12 { get; set; }
+        public global::Ideogram.GenerateImageRequest? Type12 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.AspectRatio? Type13 { get; set; }
+        public global::Ideogram.ImageRequest? Type13 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.MagicPromptVersionEnum? Type14 { get; set; }
+        public global::Ideogram.AspectRatio? Type14 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.Resolution? Type15 { get; set; }
+        public global::Ideogram.MagicPromptVersionEnum? Type15 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.ColorPaletteWithPresetNameOrMembers? Type16 { get; set; }
+        public global::Ideogram.Resolution? Type16 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.ColorPaletteWithPresetName? Type17 { get; set; }
+        public global::Ideogram.ColorPaletteWithPresetNameOrMembers? Type17 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.ColorPalettePresetName? Type18 { get; set; }
+        public global::Ideogram.ColorPaletteWithPresetName? Type18 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.ColorPaletteWithMembers? Type19 { get; set; }
+        public global::Ideogram.ColorPalettePresetName? Type19 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Ideogram.ColorPaletteMember>? Type20 { get; set; }
+        public global::Ideogram.ColorPaletteWithMembers? Type20 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.ColorPaletteMember? Type21 { get; set; }
+        public global::System.Collections.Generic.IList<global::Ideogram.ColorPaletteMember>? Type21 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public double? Type22 { get; set; }
+        public global::Ideogram.ColorPaletteMember? Type22 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.GenerateImageRequestV3? Type23 { get; set; }
+        public double? Type23 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.ResolutionV3? Type24 { get; set; }
+        public global::Ideogram.GenerateImageRequestV3? Type24 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.AspectRatioV3? Type25 { get; set; }
+        public global::Ideogram.ResolutionV3? Type25 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.RenderingSpeed? Type26 { get; set; }
+        public global::Ideogram.AspectRatioV3? Type26 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<string>? Type27 { get; set; }
+        public global::Ideogram.RenderingSpeed? Type27 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.StyleTypeV3? Type28 { get; set; }
+        public global::System.Collections.Generic.IList<string>? Type28 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<byte[]>? Type29 { get; set; }
+        public global::Ideogram.StyleTypeV3? Type29 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.RemixImageRequestV3? Type30 { get; set; }
+        public global::System.Collections.Generic.IList<byte[]>? Type30 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.EditImageRequestV3? Type31 { get; set; }
+        public global::Ideogram.RemixImageRequestV3? Type31 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.ReframeImageRequestV3? Type32 { get; set; }
+        public global::Ideogram.EditImageRequestV3? Type32 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.ReplaceBackgroundRequestV3? Type33 { get; set; }
+        public global::Ideogram.ReframeImageRequestV3? Type33 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.InternalTestingRequest? Type34 { get; set; }
+        public global::Ideogram.ReplaceBackgroundRequestV3? Type34 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.InternalTestingNestedObject? Type35 { get; set; }
+        public global::Ideogram.InternalTestingRequest? Type35 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.InternalTestingNestedObjectRequiredFields? Type36 { get; set; }
+        public global::Ideogram.InternalTestingNestedObject? Type36 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.DateTime? Type37 { get; set; }
+        public global::Ideogram.InternalTestingNestedObjectRequiredFields? Type37 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Ideogram.InternalTestingNestedObject>? Type38 { get; set; }
+        public global::System.DateTime? Type38 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.InternalTestingEnumField? Type39 { get; set; }
+        public global::System.Collections.Generic.IList<global::Ideogram.InternalTestingNestedObject>? Type39 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.RemixImageRequest? Type40 { get; set; }
+        public global::Ideogram.InternalTestingEnumField? Type40 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.InitialImageRequest? Type41 { get; set; }
+        public global::Ideogram.RemixImageRequest? Type41 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.ReframeImageRequest? Type42 { get; set; }
+        public global::Ideogram.InitialImageRequest? Type42 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.UpscaleImageRequest? Type43 { get; set; }
+        public global::Ideogram.ReframeImageRequest? Type43 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.UpscaleInitialImageRequest? Type44 { get; set; }
+        public global::Ideogram.UpscaleImageRequest? Type44 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.GenerateImageResponse? Type45 { get; set; }
+        public global::Ideogram.UpscaleInitialImageRequest? Type45 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Ideogram.ImageObject>? Type46 { get; set; }
+        public global::Ideogram.GenerateImageResponse? Type46 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.ImageObject? Type47 { get; set; }
+        public global::System.Collections.Generic.IList<global::Ideogram.ImageObject>? Type47 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public bool? Type48 { get; set; }
+        public global::Ideogram.ImageObject? Type48 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.ImageGenerationResponseV3? Type49 { get; set; }
+        public bool? Type49 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Ideogram.ImageGenerationObjectV3>? Type50 { get; set; }
+        public global::Ideogram.ImageGenerationResponseV3? Type50 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.ImageGenerationObjectV3? Type51 { get; set; }
+        public global::System.Collections.Generic.IList<global::Ideogram.ImageGenerationObjectV3>? Type51 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.GenerateImageSafetyError? Type52 { get; set; }
+        public global::Ideogram.ImageGenerationObjectV3? Type52 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.ImageSafetyError? Type53 { get; set; }
+        public global::Ideogram.GenerateImageSafetyError? Type53 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.ManageApiSubscriptionResponse? Type54 { get; set; }
+        public global::Ideogram.ImageSafetyError? Type54 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.MetronomeLinks? Type55 { get; set; }
+        public global::Ideogram.ManageApiSubscriptionResponse? Type55 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.RechargeSettingsResponse? Type56 { get; set; }
+        public global::Ideogram.MetronomeLinks? Type56 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.RechargeSettings? Type57 { get; set; }
+        public global::Ideogram.RechargeSettingsResponse? Type57 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.Price? Type58 { get; set; }
+        public global::Ideogram.RechargeSettings? Type58 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.PostApiSubscriptionResponse? Type59 { get; set; }
+        public global::Ideogram.Price? Type59 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.PostApiSubscriptionError? Type60 { get; set; }
+        public global::Ideogram.PostApiSubscriptionResponse? Type60 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.PostApiSubscriptionRequest? Type61 { get; set; }
+        public global::Ideogram.PostApiSubscriptionError? Type61 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.PostApiReactivateResponse? Type62 { get; set; }
+        public global::Ideogram.PostApiSubscriptionRequest? Type62 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.GetApiKeysResponse? Type63 { get; set; }
+        public global::Ideogram.PostApiReactivateResponse? Type63 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Ideogram.RedactedApiKey>? Type64 { get; set; }
+        public global::Ideogram.GetApiKeysResponse? Type64 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.RedactedApiKey? Type65 { get; set; }
+        public global::System.Collections.Generic.IList<global::Ideogram.RedactedApiKey>? Type65 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.PostApiKeyResponse? Type66 { get; set; }
+        public global::Ideogram.RedactedApiKey? Type66 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.ManageApiStripeSubscriptionResponse? Type67 { get; set; }
+        public global::Ideogram.PostApiKeyResponse? Type67 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.GetApiTermsResponse? Type68 { get; set; }
+        public global::Ideogram.ManageApiStripeSubscriptionResponse? Type68 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.ApiTerms? Type69 { get; set; }
+        public global::Ideogram.GetApiTermsResponse? Type69 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.PostApiTermsRequest? Type70 { get; set; }
+        public global::Ideogram.ApiTerms? Type70 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.PostAddCreditsResponse? Type71 { get; set; }
+        public global::Ideogram.PostApiTermsRequest? Type71 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.PostAddCreditsError? Type72 { get; set; }
+        public global::Ideogram.PostAddCreditsResponse? Type72 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.PostAddCreditsRequest? Type73 { get; set; }
+        public global::Ideogram.PostAddCreditsError? Type73 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ideogram.PostInternalTesting200Response? Type74 { get; set; }
+        public global::Ideogram.PostAddCreditsRequest? Type74 { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public global::Ideogram.PostInternalTesting200Response? Type75 { get; set; }
     }
 }

--- a/src/libs/Ideogram/openapi.yaml
+++ b/src/libs/Ideogram/openapi.yaml
@@ -882,6 +882,8 @@ components:
           type: string
           description: 'An image binary (max size 10MB); only JPEG, WebP and PNG formats are supported at this time.'
           format: binary
+        describe_model_version:
+          $ref: '#/components/schemas/DescribeModelVersion'
     EditImageRequest:
       required:
         - image_file
@@ -1899,6 +1901,13 @@ components:
           example: 'A meticulously illustrated cat with striped patterns, sitting upright. The cat''s eyes are a captivating shade of yellow, and it appears to be gazing intently at something. The background consists of abstract, swirling patterns in shades of black, white, and beige, creating an almost fluid or wavy appearance. The cat is positioned in the foreground, with the background elements fading into the distance, giving a sense of depth to the image.'
       example:
         text: 'A meticulously illustrated cat with striped patterns, sitting upright. The cat''s eyes are a captivating shade of yellow, and it appears to be gazing intently at something. The background consists of abstract, swirling patterns in shades of black, white, and beige, creating an almost fluid or wavy appearance. The cat is positioned in the foreground, with the background elements fading into the distance, giving a sense of depth to the image.'
+    DescribeModelVersion:
+      title: DescribeModelVersion
+      enum:
+        - V_2
+        - V_3
+      type: string
+      description: 'The model version to use for describing images. V_2 uses the current describe model, V_3 uses the new captioner model.'
     MagicPromptOption:
       title: MagicPromptOption
       enum:
@@ -2035,6 +2044,7 @@ components:
     RenderingSpeed:
       title: RenderingSpeed
       enum:
+        - FLASH
         - TURBO
         - BALANCED
         - DEFAULT


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Users can now choose between different model versions (V_2 and V_3) when requesting image descriptions.
	- A new "FLASH" rendering speed option is available for image generation requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->